### PR TITLE
Fixed issue with count calculation for players#show

### DIFF
--- a/app/views/players/show.html.erb
+++ b/app/views/players/show.html.erb
@@ -80,3 +80,5 @@
     <p>No hay datos para mostrar.</p>
   <% end %>
 </div>
+
+<!-- <%= raw @teammates.transform_keys(&:name).to_json.inspect %> -->


### PR DESCRIPTION
Missed to take into account that a match has players for both teams. It
nows groups by team and counts when the match was won and when it was
lost.