### PR TITLE
API auth and options

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A server where the results of www.haxball.com matches will be stored. In Haxball
 ## Setup
 
 ### ENV vars
-Create a file `.env` and add `HOST_NAME=www.haxball.com` entry.
+Create a file `.env` and add `HOST_NAME=` entry. This is the actual host name where the app is run (i.e. haxlaton.dokku.1ma.dev)
 
 ### Install
 Execute the next commands:
@@ -26,4 +26,6 @@ Now you're ready to get the server up and running
 bundle exec rails s
 ```
 
-Enjoy!
+## Haxball client
+
+Run the server, create a room and follow the instruction to get the haxball client script.

--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -1,4 +1,12 @@
 module API
   class ApplicationController < ActionController::API
+    include ActionController::HttpAuthentication::Token::ControllerMethods
+    before_action :authenticate!
+
+    def authenticate!
+      authenticate_or_request_with_http_token do |token, options|
+        @current_room = Room.find_by(token: token)
+      end
+    end
   end
 end

--- a/app/controllers/api/players_controller.rb
+++ b/app/controllers/api/players_controller.rb
@@ -1,5 +1,7 @@
 module API
   class PlayersController < ApplicationController
+    skip_before_action :authenticate!, only: [:auth]
+
     def index
       render json: Player.all
     end

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -1,5 +1,5 @@
 class RoomsController < ApplicationController
-  before_action :authenticate_player!
+  before_action :authenticate_player!, except: :show
   skip_forgery_protection only: :show
 
   def new
@@ -28,6 +28,6 @@ class RoomsController < ApplicationController
   private
 
   def room_params
-    params.require(:room).permit(:room_name, :max_players, :password, :public)
+    params.require(:room).permit(:name, :max_players, :password, :public)
   end
 end

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -44,9 +44,22 @@ class Room < ApplicationRecord
         BUILD_PATH,
         "&& OUTFILE_NAME=#{f.path}",
         "BASE_API_URL=#{Rails.application.routes.url_helpers.root_url(host: ENV.fetch("HOST_NAME"))}api",
+        client_env,
         "node #{BUILD_PATH}/build.js"].join(" ")
       system(command)
       f.read
     end
+  end
+
+  private
+
+  def client_env
+    @client_env ||= {
+      CLIENT_TOKEN: token,
+      CLIENT_NAME: name,
+      CLIENT_PASSWORD: password,
+      CLIENT_MAX_PLAYERS: max_players,
+      CLIENT_PUBLIC: public
+    }.map { |k, v| "#{k}='#{v}'" }.join(" ")
   end
 end

--- a/app/views/rooms/new.html.erb
+++ b/app/views/rooms/new.html.erb
@@ -1,6 +1,9 @@
 <div class="max-w-lg border-2 border-gray-50 rounded px-8 py-5">
   <%= simple_form_for @room do |f| %>
     <%= f.input :name %>
+    <%= f.input :password, hint: "Dejar vacía para que la sala no tenga pass", as: :string %>
+    <%= f.input :max_players %>
+    <%= f.input :public %>
     <%= f.button :submit, "Crear la sala", class: "mt-2" %>
   <% end %>
 </div>

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -6,6 +6,7 @@
 
   <div class="max-h-32 overflow-hidden bg-gray-50 p-2 rounded" data-controller="clipboard" data-clipboard-success-content="Copiado!">
     <button class="text-blue-500 hover:underline hover:cursor-pointer block" type="button" data-action="clipboard#copy" data-clipboard-target="button">Copiar</button>
+    <%= link_to "Ir a Haxball Headless", "https://www.haxball.com/headless", class: "text-blue-500 hover:underline hover:cursor-pointer block" %>
 
     <code class="text-xs" data-clipboard-target="source">
       <%= @room.to_javascript %>

--- a/lib/haxball_client/src/chatLog.js
+++ b/lib/haxball_client/src/chatLog.js
@@ -4,7 +4,7 @@ const chatLog = {
   clear: clear,
   disable: disable,
   enable: enable,
-  enabled: false,
+  enabled: true,
   log: log,
   persist: persist
 };
@@ -56,7 +56,8 @@ function persist(matchId) {
   fetch(endpoint, {
     method: "POST",
     headers: {
-      "Content-Type": "application/json"
+      "Content-Type": "application/json",
+      "Authorization": "Bearer " + process.env.CLIENT_TOKEN
     },
     body: JSON.stringify({ messages: internalLog }),
     redirect: "follow"

--- a/lib/haxball_client/src/endGame.js
+++ b/lib/haxball_client/src/endGame.js
@@ -8,6 +8,7 @@ function postData(blob, filename, redPlayers, bluePlayers) {
   var matchPlayerStats = getMatchPlayerStats();
   var myHeaders = new Headers();
   myHeaders.append("Accept", "application/json;version=2");
+  myHeaders.append("Authorization", "Bearer " + process.env.CLIENT_TOKEN);
 
   var formdata = new FormData();
   formdata.append("match[recording]", blob, filename);

--- a/lib/haxball_client/src/playersElo.js
+++ b/lib/haxball_client/src/playersElo.js
@@ -3,8 +3,9 @@ import { getPersonalScoreboard } from "./scoreboard";
 const playersElo = async function () {
   const url = process.env.BASE_API_URL + "/players";
   let elos = {};
-  await fetch(url)
-    .then(data => data.json())
+  await fetch(url, {
+    headers: {"Authorization": "Bearer " + process.env.CLIENT_TOKEN}
+  }).then(data => data.json())
     .then(players => {
       players.forEach(player => {
         elos[player.name] = player.elo;

--- a/lib/haxball_client/src/room.js
+++ b/lib/haxball_client/src/room.js
@@ -1,9 +1,10 @@
 import { longbounceStadium } from "./stadiums/longbounce";
 
 var room = HBInit({
-	roomName: "Longaniza",
-	maxPlayers: 16,
-	noPlayer: true
+	roomName: process.env.CLIENT_NAME || "Longaniza",
+	maxPlayers: Number(process.env.CLIENT_MAX_PLAYERS || 16),
+	noPlayer: true,
+  password: process.env.CLIENT_PASSWORD || undefined,
 });
 
 room.setCustomStadium(longbounceStadium);

--- a/spec/factories/rooms.rb
+++ b/spec/factories/rooms.rb
@@ -1,9 +1,10 @@
 FactoryBot.define do
   factory :room do
-    token { "MyString" }
-    room_name { "MyString" }
-    max_players { 1 }
-    password { "MyString" }
-    public { false }
+    token { "random-token" }
+    name { "Oke oke" }
+    max_players { 16 }
+    password { "" }
+    public { true }
+    association :created_by, factory: :player
   end
 end

--- a/spec/requests/api/messages_spec.rb
+++ b/spec/requests/api/messages_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.describe API::MessagesController, type: :request do
   describe "POST /api/matches/:match_id/messages" do
+    let(:room) { create(:room, created_by: match_player.player) }
     let(:match) { create(:match) }
     let(:match_player) { create(:match_player, match: match) }
     let(:other_match_player) { create(:match_player, match: match) }
@@ -19,6 +20,7 @@ RSpec.describe API::MessagesController, type: :request do
         }
       ]
     end
+    let(:headers) { { "Authorization" => "Bearer #{room.token}" } }
 
     before do
       match_player
@@ -27,7 +29,7 @@ RSpec.describe API::MessagesController, type: :request do
     end
 
     subject do
-      post api_match_messages_path(match), params: { messages: messages }
+      post api_match_messages_path(match), params: { messages: messages }, headers: headers
     end
 
     it "creates two messages" do


### PR DESCRIPTION
Creating a room allows us to configure the actual haxball client script. Room name, password, publicly available, max players are the configurable options for the haxball client script.

Updated all api endpoints to check the Authorization header.

![image](https://user-images.githubusercontent.com/13257832/229380746-b440381d-9862-45a6-b2c8-2fd2645b2f89.png)

Solves https://github.com/juanmanuelramallo/haxlaton/issues/37